### PR TITLE
Update Matomo Java Tracker to 3.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.piwik.java.tracking</groupId>
             <artifactId>matomo-java-tracker</artifactId>
-            <version>2.0</version>
+            <version>3.0.3</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/identifiers/satellite/frontend/satellitewebspa/services/AsyncMatomoCidResolutionService.java
+++ b/src/main/java/org/identifiers/satellite/frontend/satellitewebspa/services/AsyncMatomoCidResolutionService.java
@@ -7,8 +7,9 @@ import org.identifiers.cloud.libapi.models.ServiceResponse;
 import org.identifiers.cloud.libapi.models.resolver.ParsedCompactIdentifier;
 import org.identifiers.cloud.libapi.models.resolver.ResolvedResource;
 import org.matomo.java.tracking.MatomoRequest;
-import org.matomo.java.tracking.MatomoRequestBuilder;
+import org.matomo.java.tracking.MatomoRequest.MatomoRequestBuilder;
 import org.matomo.java.tracking.MatomoTracker;
+import org.matomo.java.tracking.parameters.AcceptLanguage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
@@ -67,7 +68,8 @@ public class AsyncMatomoCidResolutionService {
     @Async("matomoThreadPoolTaskExecutor")
     private void doHandleCidResolution(MatomoRequestImportantInfo info) {
         log.debug("Info: {}", info);
-        MatomoRequestBuilder mreq = MatomoRequest.builder().siteId(1);
+        MatomoRequestBuilder mreq = MatomoRequest.request();
+        mreq.siteId(1);
 
         mreq.actionUrl(info.url);
 //        mreq.trackBotRequests(true);
@@ -106,7 +108,7 @@ public class AsyncMatomoCidResolutionService {
             log.debug("No auth token => no ip collection");
         }
         mreq.headerUserAgent(info.ua);
-        mreq.headerAcceptLanguage(info.lang);
+        mreq.headerAcceptLanguage(AcceptLanguage.fromHeader(info.lang));
         mreq.referrerUrl(info.refe);
     }
 
@@ -120,18 +122,18 @@ public class AsyncMatomoCidResolutionService {
             mreq.outlinkUrl(maxResolvedResource.getCompactIdentifierResolvedUrl());
         }
 
-        Map<String, Object> customData = new HashMap<>();
+        Map<Long, Object> customData = new HashMap<>();
         if (info.parsed_cid != null) {
-            customData.put("dimension6", info.parsed_cid.getNamespace() == null ? "" : info.parsed_cid.getNamespace());
-            customData.put("dimension7", info.parsed_cid.getProviderCode() == null ? "" : info.parsed_cid.getProviderCode());
+            customData.put(6L, info.parsed_cid.getNamespace() == null ? "" : info.parsed_cid.getNamespace());
+            customData.put(7L, info.parsed_cid.getProviderCode() == null ? "" : info.parsed_cid.getProviderCode());
         }
-        customData.put("dimension8", info.resolvedResources.size());
+        customData.put(8L, info.resolvedResources.size());
         if (maxResolvedResource != null) {
-            customData.put("dimension9", maxResolvedResource.getInstitution().getName());
-            customData.put("dimension10", maxResolvedResource.isOfficial());
-//            customData.put("dimention6", maxResolvedResource.isDeprecatedResource()); // Need to find how to add this
+            customData.put(9L, maxResolvedResource.getInstitution().getName());
+            customData.put(10L, maxResolvedResource.isOfficial());
+//            customData.put(6L, maxResolvedResource.isDeprecatedResource()); // Need to find how to add this
         }
-        mreq.customTrackingParameters(customData);
+        mreq.dimensions(customData);
     }
 }
 


### PR DESCRIPTION
### Hey @renatocjn and team,

Just wanted to give our project a little boost with the latest and greatest from Matomo Java Tracker! 🚀

### Changes in a Nutshell:

- **Bug Fixes & Performance Boosts:** Say goodbye to some pesky bugs and enjoy a faster, smoother tracking experience.

- **Security Makeover:** We're getting the latest security swag to keep our project locked down.

- **Stay Cool with Compatibility:** Now we're best buddies with Matomo versions up to 5, so no more awkward compatibility issues.

- **Less Baggage:** Matomo Java Tracker 3.0.3 is lean and mean with fewer dependencies. Less stuff, more speed!

- **New Toys:** Check out the cool new dimension parameter for super-customizable tracking.

- **Java 11 Party:** We're upgrading to the latest Java 11 implementation. It's like giving our project a cool new set of wheels.

- **Smooth Moves:** If you're coming from version 2, no worries! There's a handy migration guide [here](https://github.com/matomo-org/matomo-java-tracker#migration-from-version-2-to-302) to make the switch painless.

### How to Test:

1. Update to Matomo Java Tracker version 3.0.3.
2. Make sure our project still builds like a champ.
3. Double-check that our Matomo tracking mojo is still on point.
4. Test out any new features and give that dimension parameter a spin.

### Where to Get Help:

- Dive into the [Javadoc](https://javadoc.io/doc/org.piwik.java.tracking/matomo-java-tracker/3.0.3/index.html) for the nitty-gritty details.
- Got issues or bright ideas? Hit up the [Matomo Java Tracker GitHub](https://github.com/matomo-org/matomo-java-tracker).

### Your Feedback Matters:

Give it a whirl and let us know how it goes! Your feedback is like gold to us. 🌟

Cheers,
Daniel
